### PR TITLE
Automate Android versionCode

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -89,7 +89,8 @@ def getAppVersion() {
     return packageJson["version"]
 }
 
-def (major, minor, patch) = getAppVersion().tokenize('.')
+def (appVersion, provisional) = getAppVersion().tokenize('-')
+def (major, minor, patch) = appVersion.tokenize('.')
 def appVersionCode = ((major.toInteger() * 1000000) + (minor.toInteger() * 1000) + patch.toInteger())
 
 android {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -90,6 +90,7 @@ def getAppVersion() {
 }
 
 def (major, minor, patch) = getAppVersion().tokenize('.')
+def appVersionCode = ((major.toInteger() * 1000000) + (minor.toInteger() * 1000) + patch.toInteger())
 
 android {
     compileSdkVersion 23
@@ -99,7 +100,7 @@ android {
         applicationId "com.msupplymobile"
         minSdkVersion 16
         targetSdkVersion 22
-        versionCode patch.toInteger()
+        versionCode appVersionCode
         versionName getAppVersion()
         ndk {
             abiFilters "armeabi-v7a", "x86"


### PR DESCRIPTION
So long as we don’t have more than 999 minor or 999 patch updates in a
Major release, should be good.

Will break if say beta package.json versions are set i.e. 1.1.0-beta.1

I welcome different ideas.