### PR TITLE
Don't migrate data on fresh install

### DIFF
--- a/src/dataMigration.js
+++ b/src/dataMigration.js
@@ -21,9 +21,9 @@ export async function migrateDataToVersion(database, settings) {
     AsyncStorage.setItem(APP_VERSION_KEY, fromVersion);
     settings.delete(SETTINGS_KEYS.APP_VERSION);
   }
-  // If it was in neither local storage or settings, just set it to 0.0.0
+  // If it was in neither local storage or settings, this is a new install, so no need to migrate
   if (!fromVersion || fromVersion.length === 0) {
-    fromVersion = '0.0.0';
+    return;
   }
   // Get the new version we are upgrading to
   const toVersion = packageJson.version;


### PR DESCRIPTION
Assumes no one is upgrading from a version prior to some really early
version where we started persisting the version to disk. I think it’s
safe to assume that no one has those very early builds any more.