### PR TITLE
Allow provisional rc numbers to extend build numbers

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -89,9 +89,9 @@ def getAppVersion() {
     return packageJson["version"]
 }
 
-def (appVersion, provisional) = getAppVersion().tokenize('-')
+def (appVersion, provisional) = getAppVersion().tokenize('-rc')
 def (major, minor, patch) = appVersion.tokenize('.')
-def appVersionCode = ((major.toInteger() * 1000000) + (minor.toInteger() * 1000) + patch.toInteger())
+def appVersionCode = ((major.toInteger() * 1000000000) + (minor.toInteger() * 1000000) + (patch.toInteger() * 1000) + (provisional != null ? provisional.toInteger() : 0))
 
 android {
     compileSdkVersion 23

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -91,7 +91,7 @@ def getAppVersion() {
 
 def (appVersion, provisional) = getAppVersion().tokenize('-rc')
 def (major, minor, patch) = appVersion.tokenize('.')
-def appVersionCode = ((major.toInteger() * 1000000000) + (minor.toInteger() * 1000000) + (patch.toInteger() * 1000) + (provisional != null ? provisional.toInteger() : 0))
+def appVersionCode = ((major.toInteger() * 10000000) + (minor.toInteger() * 100000) + (patch.toInteger() * 100) + (provisional != null ? provisional.toInteger() : 0))
 
 android {
     compileSdkVersion 23

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "email": "info@sussol.net"
   },
   "name": "mSupplyMobile",
-  "version": "2.0.0",
+  "version": "must be in the format ${majorNumber}.${minorNumber}.${patchNumber}-rc${releaseCandidateNumber}",
+  "version": "2.0.0-rc1",
   "private": false,
   "license": "MIT",
   "description": "Mobile app for use with the mSupply medical inventory control software",


### PR DESCRIPTION
So that versions can be applied on top of each other as upgrades