### PR TITLE
Fixes the mSupplyMobileApp constructing again on reopen

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
         android:name=".MainActivity"
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
-        android:screenOrientation="landscape">
+        android:screenOrientation="landscape"
+        android:launchMode="singleTop">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
Have had a bug whereby if you press the ‘home’ button, but don’t
actually kill the app, then you reopen the app by tapping its icon, the
currentUser gets set to null (among other things that happen during the
MSupplyMobileApp constructor). This was bound to cause some nasty
issues, and is fixed by this change.