### PR TITLE
Sort by serial number in lists

### DIFF
--- a/src/pages/CustomerInvoicesPage.js
+++ b/src/pages/CustomerInvoicesPage.js
@@ -31,7 +31,7 @@ export class CustomerInvoicesPage extends React.Component {
     };
     this.dataFilters = {
       searchTerm: '',
-      sortBy: 'entryDate',
+      sortBy: 'serialNumber',
       isAscending: false,
     };
     autobind(this);

--- a/src/pages/CustomerRequisitionsPage.js
+++ b/src/pages/CustomerRequisitionsPage.js
@@ -26,7 +26,7 @@ export class CustomerRequisitionsPage extends React.Component {
     this.state = {};
     this.dataFilters = {
       searchTerm: '',
-      sortBy: 'entryDate',
+      sortBy: 'serialNumber',
       isAscending: false,
     };
     autobind(this);

--- a/src/pages/SupplierInvoicesPage.js
+++ b/src/pages/SupplierInvoicesPage.js
@@ -30,7 +30,7 @@ export class SupplierInvoicesPage extends React.Component {
     };
     this.dataFilters = {
       searchTerm: '',
-      sortBy: 'entryDate',
+      sortBy: 'serialNumber',
       isAscending: false,
     };
     autobind(this);

--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -32,7 +32,7 @@ export class SupplierRequisitionsPage extends React.Component {
     this.requisitions = props.database.objects('RequestRequisition');
     this.dataFilters = {
       searchTerm: '',
-      sortBy: 'entryDate',
+      sortBy: 'serialNumber',
       isAscending: false,
     };
     autobind(this);


### PR DESCRIPTION
With entered dates now not exactly matching the order of requisitions
and transactions appearing on a given mobile device, serial numbers are
a better option for sorting so that the user always sees any new
requisitions etc. at the top of the list