### PR TITLE
Use redux persist to remember last sync time and any error

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-redux": "^5.0.5",
     "realm": "^1.10.0",
     "redux": "^3.7.2",
+    "redux-persist": "^4.9.1",
     "redux-thunk": "^2.2.0",
     "set-manipulator": "0.3.1",
     "sussol-utilities": "^0.4.5"

--- a/src/main.js
+++ b/src/main.js
@@ -3,23 +3,28 @@
  * Sustainable Solutions (NZ) Ltd. 2016
  */
 
+/* eslint-disable no-unused-vars */
+
 import React from 'react';
-import { AppRegistry } from 'react-native';
+import { AppRegistry, AsyncStorage } from 'react-native';
 import { Provider } from 'react-redux';
 import { applyMiddleware, createStore } from 'redux';
 import thunk from 'redux-thunk';
+import { persistStore } from 'redux-persist';
 import { Client as BugsnagClient } from 'bugsnag-react-native';
 
 import { MSupplyMobileApp } from './mSupplyMobileApp';
 import { reducers } from './reducers';
 
-const bugsnagClient = new BugsnagClient(); // eslint-disable-line no-unused-vars
+const bugsnagClient = new BugsnagClient();
 
 const store = createStore(
   reducers,
   {},
   applyMiddleware(thunk),
 );
+
+const persistedStore = persistStore(store, { storage: AsyncStorage });
 
 function App() {
   return (

--- a/src/sync/reducer.js
+++ b/src/sync/reducer.js
@@ -2,8 +2,7 @@
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2016
  */
-
-import { createReducer } from '../utilities';
+import { createReducer, REHYDRATE } from '../utilities';
 
 import {
     INCREMENT_SYNC_PROGRESS,
@@ -50,6 +49,14 @@ const stateChanges = {
   [SET_SYNC_COMPLETION_TIME]: ({ lastSyncTime }) => ({
     lastSyncTime,
   }),
+  [REHYDRATE]: ({ sync: persistedSyncState = {} }) => {
+    // For sync, we want to keep any error message and last sync time persistent across sessions
+    const { errorMessage, lastSyncTime } = persistedSyncState;
+    return {
+      errorMessage,
+      lastSyncTime,
+    };
+  },
 };
 
 export const reducer = createReducer(defaultState, stateChanges);

--- a/src/utilities/createReducer.js
+++ b/src/utilities/createReducer.js
@@ -3,10 +3,18 @@
  * Sustainable Solutions (NZ) Ltd. 2016
  */
 
+import { REHYDRATE } from 'redux-persist/constants';
+export { REHYDRATE };
 
 /**
 * Helper function that returns a reducer based on an object that contains an entry for each action
 * type, with a function that describes what changes to state that action would cause.
+* @param  {object}   defaultState   The default state of the reducer
+* @param  {object}   stateChanges   An object containing a function for each action constant, which
+*                                   takes the payload of the action and the current state as params,
+*                                   and returns the new state. Can opt in to rehydration by
+*                                   including an entry for the REHYDRATE action
+* @return {function} reducer        A redux reducer
 **/
 export const createReducer = (defaultState = {}, stateChanges = {}) =>
     (state = defaultState, action) => {

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -10,4 +10,4 @@ export {
 } from 'sussol-utilities';
 export { formatStatus } from './formatStatus';
 export { sortDataBy } from './sortDataBy';
-export { createReducer } from './createReducer';
+export { createReducer, REHYDRATE } from './createReducer';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3395,7 +3395,7 @@ json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
@@ -3514,7 +3514,7 @@ loader-utils@^1.0.2:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
 
-lodash-es@^4.2.0, lodash-es@^4.2.1:
+lodash-es@^4.17.4, lodash-es@^4.2.0, lodash-es@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
 
@@ -4952,6 +4952,14 @@ redeyed@~1.0.0:
   resolved "https://registry.yarnpkg.com/redeyed/-/redeyed-1.0.1.tgz#e96c193b40c0816b00aec842698e61185e55498a"
   dependencies:
     esprima "~3.0.0"
+
+redux-persist@^4.9.1:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-4.9.1.tgz#271fa31d1c782ebf9082fb5174e829db24faf59e"
+  dependencies:
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.4"
+    lodash-es "^4.17.4"
 
 redux-thunk@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Note: not using autoRehydrate, so that this is an ‘opt-in’ system,
where a reducer must provide the REHYDRATE action in order to have some
part of state persisted. This is to avoid redux-persist unexpectedly
remembering too much (e.g. we don’t want navigation persisted)