### PR TITLE
#540 Parse as int, use set method, right align value

### DIFF
--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import autobind from 'react-autobind';
 import {
   formatDate,
-  parsePositiveFloat,
+  parsePositiveInteger,
   sortDataBy,
 } from '../utilities';
 import { createRecord } from '../database';
@@ -88,7 +88,7 @@ export class SupplierInvoicePage extends React.Component {
     database.write(() => {
       switch (key) {
         case 'numberOfPacks':
-          transactionBatch.numberOfPacks = parsePositiveFloat(newValue);
+          transactionBatch.setTotalQuantity(database, parsePositiveInteger(newValue));
           break;
         case 'expiryDate':
           transactionBatch.expiryDate = newValue;
@@ -338,7 +338,7 @@ export class SupplierInvoicePage extends React.Component {
             key: 'numberOfPacks',
             width: 1,
             title: tableStrings.quantity,
-            alignText: 'center',
+            alignText: 'right',
           },
           {
             key: 'expiryDate',

--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -36,7 +36,7 @@ const SORT_DATA_TYPES = {
   itemName: 'string',
   itemCode: 'string',
   batch: 'string',
-  numberOfPacks: 'number',
+  totalQuantity: 'number',
   packSize: 'number',
 };
 
@@ -81,7 +81,7 @@ export class SupplierInvoicePage extends React.Component {
     const { database } = this.props;
     database.write(() => {
       switch (key) {
-        case 'quantity':
+        case 'totalQuantity':
           // Should edit the numberOfPacks directly if packSize becomes an editable column
           // that represents the number of packs counted
           transactionBatch.setTotalQuantity(database, parsePositiveInteger(newValue));
@@ -206,7 +206,7 @@ export class SupplierInvoicePage extends React.Component {
         return {
           cellContents: transactionBatch[key],
         };
-      case 'numberOfPacks':
+      case 'totalQuantity':
         return editableCell;
       case 'expiryDate': {
         return (
@@ -316,7 +316,7 @@ export class SupplierInvoicePage extends React.Component {
             sortable: true,
           },
           {
-            key: 'quantity',
+            key: 'totalQuantity',
             width: 1,
             title: tableStrings.quantity,
             alignText: 'right',

--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -87,7 +87,9 @@ export class SupplierInvoicePage extends React.Component {
     const { database } = this.props;
     database.write(() => {
       switch (key) {
-        case 'numberOfPacks':
+        case 'quantity':
+          // Should edit the numberOfPacks directly if packSize becomes an editable column
+          // that represents the number of packs counted
           transactionBatch.setTotalQuantity(database, parsePositiveInteger(newValue));
           break;
         case 'expiryDate':
@@ -335,7 +337,7 @@ export class SupplierInvoicePage extends React.Component {
             sortable: true,
           },
           {
-            key: 'numberOfPacks',
+            key: 'quantity',
             width: 1,
             title: tableStrings.quantity,
             alignText: 'right',


### PR DESCRIPTION
~~Was meant to fix issue #540, but it doesn't really make sense. Doesn't seem to consistently throw the bug anymore, even if I switch back to master branch...~~

Fixes #540, I was testing with spacebar rather than backspace. Has to actually be an empty string for the bug to occur.

Changes are consistent with implementation elsewhere in app.