### PR TITLE
#xxxx item cross reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "name": "mSupplyMobile",
   "//": "version must be in the format ${majorNumber}.${minorNumber}.${patchNumber}-rc${releaseCandidateNumber}",
-  "version": "2.1.0-rc7",
+  "version": "2.1.0-rc10",
   "private": false,
   "license": "MIT",
   "description": "Mobile app for use with the mSupply medical inventory control software",

--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -9,7 +9,8 @@ export class Item extends Realm.Object {
   }
 
   get totalQuantity() {
-    return getTotal(this.batches, 'totalQuantity');
+    const item = this.crossReferenceItem ? this.crossReferenceItem : this;
+    return getTotal(item.batches, 'totalQuantity');
   }
 
   get dailyUsage() {
@@ -124,5 +125,6 @@ Item.schema = {
     category: { type: 'ItemCategory', optional: true },
     defaultPrice: { type: 'double', optional: true },
     isVisible: { type: 'bool', default: false },
+    crossReferenceItem: { type: 'Item', optional: true },
   },
 };

--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -8,9 +8,17 @@ export class Item extends Realm.Object {
     database.delete('ItemBatch', this.batches);
   }
 
+  /**
+   * A useful getter to ensure that if the item is a cross reference item,
+   * we use the item it references (the real item) rather than the cross
+   * reference item
+   */
+  get realItem() {
+    return this.crossReferenceItem ? this.crossReferenceItem : this;
+  }
+
   get totalQuantity() {
-    const item = this.crossReferenceItem ? this.crossReferenceItem : this;
-    return getTotal(item.batches, 'totalQuantity');
+    return getTotal(this.realItem.batches, 'totalQuantity');
   }
 
   get dailyUsage() {

--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -52,7 +52,7 @@ export class Requisition extends Realm.Object {
   }
 
   hasItem(item) {
-    const itemId = item.crossReferenceItem ? item.crossReferenceItem.id : item.id;
+    const itemId = item.realItem.id;
     return this.items.filtered('item.id == $0', itemId).length > 0;
   }
 

--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -93,8 +93,12 @@ export class Requisition extends Realm.Object {
       const itemsToAdd = complement(masterList.items,
                                     this.items,
                                     (item) => item.itemId);
-      itemsToAdd.forEach(masterListItem =>
-        createRecord(database, 'RequisitionItem', this, masterListItem.item));
+      itemsToAdd.forEach(masterListItem => {
+        if (!masterListItem.item.crossReferenceItem) {
+          // Don't add cross reference items or we'll get duplicates
+          createRecord(database, 'RequisitionItem', this, masterListItem.item);
+        }
+      });
     });
   }
 

--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -51,7 +51,8 @@ export class Requisition extends Realm.Object {
     this.daysToSupply = months * 30;
   }
 
-  hasItemWithId(itemId) {
+  hasItem(item) {
+    const itemId = item.crossReferenceItem ? item.crossReferenceItem.id : item.id;
     return this.items.filtered('item.id == $0', itemId).length > 0;
   }
 

--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -108,9 +108,12 @@ export class Transaction extends Realm.Object {
     if (this.otherParty) {
       this.otherParty.masterLists.forEach(masterList => {
         const itemsToAdd = complement(masterList.items, this.items, item => item.itemId);
-        itemsToAdd.forEach(masterListItem =>
-          createRecord(database, 'TransactionItem', this, masterListItem.item)
-        );
+        itemsToAdd.forEach(masterListItem => {
+          if (!masterListItem.item.crossReferenceItem) {
+            // Don't add cross reference items or we'll get duplicates
+            createRecord(database, 'TransactionItem', this, masterListItem.item);
+          }
+        });
       });
     }
   }

--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -85,7 +85,8 @@ export class Transaction extends Realm.Object {
     return !!this.linkedRequisition;
   }
 
-  hasItemWithId(itemId) {
+  hasItem(item) {
+    const itemId = item.crossReferenceItem ? item.crossReferenceItem.id : item.id;
     return this.items.filtered('item.id == $0', itemId).length > 0;
   }
 

--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -86,7 +86,7 @@ export class Transaction extends Realm.Object {
   }
 
   hasItem(item) {
-    const itemId = item.crossReferenceItem ? item.crossReferenceItem.id : item.id;
+    const itemId = item.realItem.id;
     return this.items.filtered('item.id == $0', itemId).length > 0;
   }
 

--- a/src/database/schema.js
+++ b/src/database/schema.js
@@ -141,5 +141,5 @@ export const schema =
       StocktakeBatch,
       User,
     ],
-    schemaVersion: 4,
+    schemaVersion: 5,
   };

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -108,17 +108,19 @@ function createInventoryAdjustment(database, user, date, isAddition) {
 
 // Creates a new empty ItemBatch and adds it to the item
 function createItemBatch(database, item, batchString) {
+  // Handle cross reference items
+  const realItem = item.crossReferenceItem || item;
   const itemBatch = database.create('ItemBatch', {
     id: generateUUID(),
-    item: item,
+    item: realItem,
     batch: batchString,
     packSize: 1,
     numberOfPacks: 0,
-    costPrice: item.defaultPrice ? item.defaultPrice : 0,
-    sellPrice: item.defaultPrice ? item.defaultPrice : 0,
+    costPrice: realItem.defaultPrice ? realItem.defaultPrice : 0,
+    sellPrice: realItem.defaultPrice ? realItem.defaultPrice : 0,
   });
-  item.addBatch(itemBatch);
-  database.save('Item', item);
+  realItem.addBatch(itemBatch);
+  database.save('Item', realItem);
   return itemBatch;
 }
 
@@ -139,13 +141,15 @@ function createRequisition(database, user, otherStoreName) {
 }
 
 // Creates a RequisitionItem and adds it to the requisition.
-function createRequisitionItem(database, requisition, item, dailyUsage = item.dailyUsage) {
+function createRequisitionItem(database, requisition, item, dailyUsage) {
+  // Handle cross reference items
+  const realItem = item.crossReferenceItem || item;
   const requisitionItem = database.create('RequisitionItem', {
     id: generateUUID(),
-    item: item,
+    item: realItem,
     requisition: requisition,
-    stockOnHand: item.totalQuantity,
-    dailyUsage: dailyUsage,
+    stockOnHand: realItem.totalQuantity,
+    dailyUsage: dailyUsage || realItem.dailyUsage,
     requiredQuantity: 0,
     comment: '',
     sortIndex: requisition.items.length + 1,
@@ -173,9 +177,11 @@ function createStocktake(database, user) {
 
 // Creates a StocktakeItem and adds it to the Stocktake.
 function createStocktakeItem(database, stocktake, item) {
+  // Handle cross reference items
+  const realItem = item.crossReferenceItem || item;
   const stocktakeItem = database.create('StocktakeItem', {
     id: generateUUID(),
-    item: item,
+    item: realItem,
     stocktake: stocktake,
   });
   stocktake.items.push(stocktakeItem);
@@ -247,9 +253,11 @@ function createTransactionBatch(database, transactionItem, itemBatch) {
 
 // Creates a TransactionItem and adds it to the Transaction
 function createTransactionItem(database, transaction, item) {
+  // Handle cross reference items
+  const realItem = item.crossReferenceItem || item;
   const transactionItem = database.create('TransactionItem', {
     id: generateUUID(),
-    item: item,
+    item: realItem,
     transaction: transaction,
   });
   transaction.addItem(transactionItem);

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -109,7 +109,7 @@ function createInventoryAdjustment(database, user, date, isAddition) {
 // Creates a new empty ItemBatch and adds it to the item
 function createItemBatch(database, item, batchString) {
   // Handle cross reference items
-  const realItem = item.crossReferenceItem || item;
+  const realItem = item.realItem;
   const itemBatch = database.create('ItemBatch', {
     id: generateUUID(),
     item: realItem,
@@ -143,7 +143,7 @@ function createRequisition(database, user, otherStoreName) {
 // Creates a RequisitionItem and adds it to the requisition.
 function createRequisitionItem(database, requisition, item, dailyUsage) {
   // Handle cross reference items
-  const realItem = item.crossReferenceItem || item;
+  const realItem = item.realItem;
   const requisitionItem = database.create('RequisitionItem', {
     id: generateUUID(),
     item: realItem,
@@ -178,7 +178,7 @@ function createStocktake(database, user) {
 // Creates a StocktakeItem and adds it to the Stocktake.
 function createStocktakeItem(database, stocktake, item) {
   // Handle cross reference items
-  const realItem = item.crossReferenceItem || item;
+  const realItem = item.realItem;
   const stocktakeItem = database.create('StocktakeItem', {
     id: generateUUID(),
     item: realItem,
@@ -254,7 +254,7 @@ function createTransactionBatch(database, transactionItem, itemBatch) {
 // Creates a TransactionItem and adds it to the Transaction
 function createTransactionItem(database, transaction, item) {
   // Handle cross reference items
-  const realItem = item.crossReferenceItem || item;
+  const realItem = item.realItem;
   const transactionItem = database.create('TransactionItem', {
     id: generateUUID(),
     item: realItem,

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -213,9 +213,13 @@ export class CustomerInvoicePage extends GenericPage {
             queryStringSecondary={'name CONTAINS[c] $0'}
             sortByString={'name'}
             onSelect={(item) => {
+              console.log('====================================');
+              console.log(!!item.crossReferenceItem);
+              console.log('====================================');
+              const selectedItem = item.crossReferenceItem ? item.crossReferenceItem : item;
               database.write(() => {
-                if (!transaction.hasItemWithId(item.id)) {
-                  createRecord(database, 'TransactionItem', transaction, item);
+                if (!transaction.hasItemWithId(selectedItem.id)) {
+                  createRecord(database, 'TransactionItem', transaction, selectedItem);
                 }
               });
               this.refreshData();

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -213,13 +213,9 @@ export class CustomerInvoicePage extends GenericPage {
             queryStringSecondary={'name CONTAINS[c] $0'}
             sortByString={'name'}
             onSelect={(item) => {
-              console.log('====================================');
-              console.log(!!item.crossReferenceItem);
-              console.log('====================================');
-              const selectedItem = item.crossReferenceItem ? item.crossReferenceItem : item;
               database.write(() => {
-                if (!transaction.hasItemWithId(selectedItem.id)) {
-                  createRecord(database, 'TransactionItem', transaction, selectedItem);
+                if (!transaction.hasItem(item)) {
+                  createRecord(database, 'TransactionItem', transaction, item);
                 }
               });
               this.refreshData();

--- a/src/pages/StockPage.js
+++ b/src/pages/StockPage.js
@@ -24,7 +24,7 @@ export class StockPage extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      items: props.database.objects('Item').filtered('crossReferenceItem = null'),
+      items: props.database.objects('Item').filtered('crossReferenceItem == null'),
     };
     this.dataFilters = {
       searchTerm: '',

--- a/src/pages/StockPage.js
+++ b/src/pages/StockPage.js
@@ -24,7 +24,7 @@ export class StockPage extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      items: props.database.objects('Item'),
+      items: props.database.objects('Item').filtered('crossReferenceItem = null'),
     };
     this.dataFilters = {
       searchTerm: '',

--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -35,7 +35,7 @@ const DATA_TYPES_SYNCHRONISED = ['Item', 'ItemBatch'];
 export class StocktakeManagePage extends React.Component {
   constructor(props) {
     super(props);
-    this.items = props.database.objects('Item');
+    this.items = props.database.objects('Item').filtered('crossReferenceItem == null');
     this.state = {
       showItemsWithNoStock: true,
       stocktakeName: '',
@@ -140,7 +140,6 @@ export class StocktakeManagePage extends React.Component {
     const { showItemsWithNoStock } = this.state;
     let data;
     data = this.items.filtered('name BEGINSWITH[c] $0 OR code BEGINSWITH[c] $0', searchTerm);
-    data = this.items.filtered('crossReferenceItem = null');
     data = data.sorted(sortBy, !isAscending);
     if (!showItemsWithNoStock) {
       data = data.slice().filter((item) => item.totalQuantity !== 0);

--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -140,6 +140,7 @@ export class StocktakeManagePage extends React.Component {
     const { showItemsWithNoStock } = this.state;
     let data;
     data = this.items.filtered('name BEGINSWITH[c] $0 OR code BEGINSWITH[c] $0', searchTerm);
+    data = this.items.filtered('crossReferenceItem = null');
     data = data.sorted(sortBy, !isAscending);
     if (!showItemsWithNoStock) {
       data = data.slice().filter((item) => item.totalQuantity !== 0);

--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -241,8 +241,7 @@ export class SupplierInvoicePage extends React.Component {
             queryStringSecondary={'name CONTAINS[c] $0'}
             sortByString={'name'}
             onSelect={item => {
-              const selectedItem = item.crossReferenceItem ? item.crossReferenceItem : item;
-              this.addNewLine(selectedItem);
+              this.addNewLine(item);
               this.refreshData();
               this.closeModal();
             }}

--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -241,7 +241,8 @@ export class SupplierInvoicePage extends React.Component {
             queryStringSecondary={'name CONTAINS[c] $0'}
             sortByString={'name'}
             onSelect={item => {
-              this.addNewLine(item);
+              const selectedItem = item.crossReferenceItem ? item.crossReferenceItem : item;
+              this.addNewLine(selectedItem);
               this.refreshData();
               this.closeModal();
             }}

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -246,9 +246,10 @@ export class SupplierRequisitionPage extends React.Component {
             sortByString={'name'}
             onSelect={(item) => {
               const { database, requisition } = this.props;
+              const selectedItem = item.crossReferenceItem ? item.crossReferenceItem : item;
               database.write(() => {
-                if (!requisition.hasItemWithId(item.id)) {
-                  createRecord(database, 'RequisitionItem', requisition, item);
+                if (!requisition.hasItemWithId(selectedItem.id)) {
+                  createRecord(database, 'RequisitionItem', requisition, selectedItem);
                   database.save('Requisition', requisition);
                 }
               });

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -246,11 +246,9 @@ export class SupplierRequisitionPage extends React.Component {
             sortByString={'name'}
             onSelect={(item) => {
               const { database, requisition } = this.props;
-              const selectedItem = item.crossReferenceItem ? item.crossReferenceItem : item;
               database.write(() => {
-                if (!requisition.hasItemWithId(selectedItem.id)) {
-                  createRecord(database, 'RequisitionItem', requisition, selectedItem);
-                  database.save('Requisition', requisition);
+                if (!requisition.hasItem(item)) {
+                  createRecord(database, 'RequisitionItem', requisition, item);
                 }
               });
               this.refreshData();

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -71,7 +71,11 @@ export function createOrUpdateRecord(database, settings, recordType, record) {
         department: database.getOrCreate('ItemDepartment', record.department_ID),
         description: record.description,
         name: record.item_name,
+        crossReferenceItem: database.getOrCreate('Item', record.cross_ref_ID),
       };
+      console.log('====================================');
+      console.log(record);
+      console.log('====================================');
       database.update(recordType, internalRecord);
       break;
     }

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -296,7 +296,7 @@ export function createOrUpdateRecord(database, settings, recordType, record) {
         sortIndex: parseNumber(record.line_number),
       };
       const requisitionItem = database.update(recordType, internalRecord);
-      requisition.addItemIfUnique(requisitionItem);
+      requisition.addItemIfUnique(requisitionItem); // requisitionItem will be an orphan record if it's not unique?
       database.save('Requisition', requisition);
       break;
     }

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -71,7 +71,7 @@ export function createOrUpdateRecord(database, settings, recordType, record) {
         department: database.getOrCreate('ItemDepartment', record.department_ID),
         description: record.description,
         name: record.item_name,
-        crossReferenceItem: database.getOrCreate('Item', record.cross_ref_ID),
+        crossReferenceItem: database.getOrCreate('Item', record.cross_ref_item_ID),
       };
       console.log('====================================');
       console.log(record);

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -73,9 +73,6 @@ export function createOrUpdateRecord(database, settings, recordType, record) {
         name: record.item_name,
         crossReferenceItem: database.getOrCreate('Item', record.cross_ref_item_ID),
       };
-      console.log('====================================');
-      console.log(record);
-      console.log('====================================');
       database.update(recordType, internalRecord);
       break;
     }


### PR DESCRIPTION
fixes #622 

If existing sites have already used cross reference items and made item batches for them... it's a bit late. The most solid resolution I have is to merge the cross reference items with the items they reference, then recreate the cross reference item (as it definitely should have been the one deleted in the merge). This should sync out to mobile safely. @GaryWilletts @ujwalSussol @craigdrown @bijaySussol @andreievg @adrianwb any other ideas or caveats?

Hey you can actually tag groups @sussol/msupplyadmin 

Alternative is a more manual version of the same thing, making inventory adjustments for the real items adding the stock and deleting the stock on the cross reference items.

# Testing
Cross reference item to be referred to as CRI below.
- [ ] Syncs CRIs safely and sets crossReferenceItem (can check in realm explorer)
- [ ] Adding an CRI in customer invoice works adds the referenced item
- [ ] Doing it twice does nothing! (no duplicates)
- [ ] CRIs are ignored adding master list items to customer invoice (no duplicates, no CRI line)
- [ ] Adding CRI in Supplier Requisition adds the referenced item
- [ ] Doing it twice does nothing! (no duplicates)
- [ ] CRIs are ignored adding master list items to supplier invoice (no duplicates, no CRI line)
- [ ] CRIs are hidden in current stock table
- [ ] CRIs are hidden in manage stock take table