### PR TITLE
#638 fix stocktake ledger issue

### DIFF
--- a/src/database/DataTypes/Stocktake.js
+++ b/src/database/DataTypes/Stocktake.js
@@ -144,10 +144,9 @@ export class Stocktake extends Realm.Object {
     database.delete('StocktakeBatch', stocktakeBatches.filter(stocktakeBatch =>
       stocktakeBatch.snapshotTotalQuantity === 0 && stocktakeBatch.difference === 0));
 
-    // Apply inventory adjustement to remaining StocktakeBatches
-    const changedStocktakeBatches = stocktakeBatches.filter(stocktakeBatch =>
-      stocktakeBatch.difference !== 0);
-    changedStocktakeBatches.forEach((stocktakeBatch) => stocktakeBatch.finalise(database));
+    // stocktakeBatch.finalise handles optimisation based on what fields were entered
+    // i.e. count/batch/expiry
+    stocktakeBatches.forEach((stocktakeBatch) => stocktakeBatch.finalise(database));
   }
 }
 

--- a/src/database/DataTypes/StocktakeBatch.js
+++ b/src/database/DataTypes/StocktakeBatch.js
@@ -24,7 +24,7 @@ export class StocktakeBatch extends Realm.Object {
    * stock on hand for this batch would result in a negative, return true. Can occur
    * when stock has been issued in a customer invoice for this batch before the parent
    * stocktake was finalised.
-   * @return {boolean} True if (stock on hand - stocktakebatch.difference) is negative
+   * @return {boolean} True if (stock on hand + stocktakebatch.difference) is negative
    */
   get isReducedBelowMinimum() {
     const stockOnHand = this.itemBatch.totalQuantity;

--- a/src/database/DataTypes/StocktakeBatch.js
+++ b/src/database/DataTypes/StocktakeBatch.js
@@ -71,6 +71,8 @@ export class StocktakeBatch extends Realm.Object {
       transactionItem, this.itemBatch);
 
     // Apply difference from stocktake to actual stock on hand levels.
+    // Whether stock is increased or decreased is determined by the transaction
+    // so we need to use the absolute value of difference (i.e. always treat as positive)
     const snapshotDifference = Math.abs(this.snapshotTotalQuantity - this.countedTotalQuantity);
     transactionBatch.setTotalQuantity(database, snapshotDifference);
 

--- a/src/database/DataTypes/StocktakeBatch.js
+++ b/src/database/DataTypes/StocktakeBatch.js
@@ -19,6 +19,11 @@ export class StocktakeBatch extends Realm.Object {
     return this.countedNumberOfPacks * this.packSize;
   }
 
+  get isReducedBelowMinimum() {
+    const stockOnHand = this.itemBatch.totalQuantity;
+    return (stockOnHand - Math.abs(this.difference)) < 0;
+  }
+
   get hasBeenCounted() {
     return this.countedNumberOfPacks !== null;
   }

--- a/src/database/DataTypes/StocktakeBatch.js
+++ b/src/database/DataTypes/StocktakeBatch.js
@@ -19,11 +19,13 @@ export class StocktakeBatch extends Realm.Object {
     return this.countedNumberOfPacks * this.packSize;
   }
 
-    /**
-     * Stock on hand should never be made negative. If the difference applied to the
-     * stock on hand for this batch would result in a negative, return true.
-     * @return {boolean} True if stock on hand - stocktakebatch.difference is negative
-     */
+  /**
+   * Stock on hand should never be made negative. If the difference applied to the
+   * stock on hand for this batch would result in a negative, return true. Can occur
+   * when stock has been issued in a customer invoice for this batch before the parent
+   * stocktake was finalised.
+   * @return {boolean} True if stock on hand - stocktakebatch.difference is negative
+   */
   get isReducedBelowMinimum() {
     const stockOnHand = this.itemBatch.totalQuantity;
     return (stockOnHand + this.difference) < 0;

--- a/src/database/DataTypes/StocktakeBatch.js
+++ b/src/database/DataTypes/StocktakeBatch.js
@@ -19,9 +19,14 @@ export class StocktakeBatch extends Realm.Object {
     return this.countedNumberOfPacks * this.packSize;
   }
 
+    /**
+     * Stock on hand should never be made negative. If the difference applied to the
+     * stock on hand for this batch would result in a negative, return true.
+     * @return {boolean} True if stock on hand - stocktakebatch.difference is negative
+     */
   get isReducedBelowMinimum() {
     const stockOnHand = this.itemBatch.totalQuantity;
-    return (stockOnHand - Math.abs(this.difference)) < 0;
+    return (stockOnHand + this.difference) < 0;
   }
 
   get hasBeenCounted() {

--- a/src/database/DataTypes/StocktakeBatch.js
+++ b/src/database/DataTypes/StocktakeBatch.js
@@ -24,7 +24,7 @@ export class StocktakeBatch extends Realm.Object {
    * stock on hand for this batch would result in a negative, return true. Can occur
    * when stock has been issued in a customer invoice for this batch before the parent
    * stocktake was finalised.
-   * @return {boolean} True if stock on hand - stocktakebatch.difference is negative
+   * @return {boolean} True if (stock on hand - stocktakebatch.difference) is negative
    */
   get isReducedBelowMinimum() {
     const stockOnHand = this.itemBatch.totalQuantity;

--- a/src/database/DataTypes/StocktakeBatch.js
+++ b/src/database/DataTypes/StocktakeBatch.js
@@ -79,7 +79,7 @@ export class StocktakeBatch extends Realm.Object {
       // Apply difference from stocktake to actual stock on hand levels.
       // Whether stock is increased or decreased is determined by the transaction
       // so we need to use the absolute value of difference (i.e. always treat as positive)
-      const snapshotDifference = Math.abs(this.snapshotTotalQuantity - this.countedTotalQuantity);
+      const snapshotDifference = Math.abs(this.difference);
       transactionBatch.setTotalQuantity(database, snapshotDifference);
       database.save('TransactionBatch', transactionBatch);
     }

--- a/src/database/DataTypes/StocktakeItem.js
+++ b/src/database/DataTypes/StocktakeItem.js
@@ -49,20 +49,6 @@ export class StocktakeItem extends Realm.Object {
   }
 
   /**
-   * If the stock has increased or not been changed since the item quantity was
-   * snapshot, the minimum is 0. If the stock has reduced since the item was
-   * snapshot, the minimum total quantity that can be sensibly considered as the
-   * counted quantity is the snapshot quantity minus the current stock on hand.
-   * This is because it doesn't make sense to count an amount that represents a
-   * reduction greater than the current stock on hand, which would create negative
-   * inventory.
-   * @return {integer} The minimum total quantity that can be sensibly counted
-   */
-  get minimumTotalQuantity() {
-    return this.item ? Math.max(0, this.snapshotTotalQuantity - this.item.totalQuantity) : 0;
-  }
-
-  /**
    * Returns true if this stocktake item's counted quantity would reduce the amount
    * of stock in inventory to negative levels, if it were finalised. This can happen
    * if, for example, an item is added to a stocktake with a snapshot quantity of

--- a/src/database/DataTypes/StocktakeItem.js
+++ b/src/database/DataTypes/StocktakeItem.js
@@ -73,10 +73,7 @@ export class StocktakeItem extends Realm.Object {
    * @return {Boolean} Whether the counted quantity is below the minimum for this item
    */
   get isReducedBelowMinimum() {
-    const countedTotalQuantity = this.countedTotalQuantity;
-    return countedTotalQuantity !== undefined &&
-           countedTotalQuantity !== null &&
-           countedTotalQuantity < this.minimumTotalQuantity;
+    return this.batches.some(batch => batch.isReducedBelowMinimum);
   }
 
   /**


### PR DESCRIPTION
Not quite a fix for #638 

Stocktake correctly applies the difference of `counted quantity - snapshot quantity` through transaction mechanism, rather than separately editing the stock on hand directly to be counted quantity.

Also, reducing stock below minimum check is done on a batch basis. Previously it checked if item total quantity would be made negative, rather than if any individual batch quantity would be made negative.