### PR TITLE
#xxxx sync delete

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "name": "mSupplyMobile",
   "//": "version must be in the format ${majorNumber}.${minorNumber}.${patchNumber}-rc${releaseCandidateNumber}",
-  "version": "2.1.0",
+  "version": "2.1.1-rc1",
   "private": false,
   "license": "MIT",
   "description": "Mobile app for use with the mSupply medical inventory control software",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "name": "mSupplyMobile",
   "//": "version must be in the format ${majorNumber}.${minorNumber}.${patchNumber}-rc${releaseCandidateNumber}",
-  "version": "2.1.1-rc1",
+  "version": "2.1.1-rc0",
   "private": false,
   "license": "MIT",
   "description": "Mobile app for use with the mSupply medical inventory control software",

--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -15,7 +15,6 @@ export class Transaction extends Realm.Object {
   }
 
   destructor(database) {
-    if (this.isFinalised) throw new Error('Cannot delete finalised transaction');
     if (this.isCustomerInvoice) {
       reuseSerialNumber(database, NUMBER_SEQUENCE_KEYS.CUSTOMER_INVOICE_NUMBER, this.serialNumber);
     }

--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -15,6 +15,7 @@ export class Transaction extends Realm.Object {
   }
 
   destructor(database) {
+    if (this.isFinalised) throw new Error('Cannot delete finalised transaction');
     if (this.isCustomerInvoice) {
       reuseSerialNumber(database, NUMBER_SEQUENCE_KEYS.CUSTOMER_INVOICE_NUMBER, this.serialNumber);
     }

--- a/src/database/UIDatabase.js
+++ b/src/database/UIDatabase.js
@@ -8,11 +8,11 @@ export class UIDatabase {
 
   objects(type) {
     const results = this.database.objects(translateToCoreDatabaseType(type));
-    const thisStoreIdSetting = this.database
+    const thisStoreNameIdSetting = this.database
       .objects('Setting')
       .filtered('key == $0', THIS_STORE_NAME_ID)[0];
     // Check ownStoreIdSetting exists, won't if not initialised
-    const thisStoreNameId = thisStoreIdSetting && thisStoreIdSetting.value;
+    const thisStoreNameId = thisStoreNameIdSetting && thisStoreNameIdSetting.value;
 
     switch (type) {
       case 'CustomerInvoice':

--- a/src/database/UIDatabase.js
+++ b/src/database/UIDatabase.js
@@ -52,17 +52,36 @@ export class UIDatabase {
     }
   }
 
-  addListener(...args) { return this.database.addListener(...args); }
-  removeListener(...args) { return this.database.removeListener(...args); }
-  alertListeners(...args) { return this.database.alertListeners(...args); }
-  create(...args) { return this.database.create(...args); }
-  getOrCreate(...args) { return this.database.getOrCreate(...args); }
-  delete(...args) { return this.database.delete(...args); }
-  deleteAll(...args) { return this.database.deleteAll(...args); }
-  save(...args) { return this.database.save(...args); }
-  update(...args) { return this.database.update(...args); }
-  write(...args) { return this.database.write(...args); }
-
+  addListener(...args) {
+    return this.database.addListener(...args);
+  }
+  removeListener(...args) {
+    return this.database.removeListener(...args);
+  }
+  alertListeners(...args) {
+    return this.database.alertListeners(...args);
+  }
+  create(...args) {
+    return this.database.create(...args);
+  }
+  getOrCreate(...args) {
+    return this.database.getOrCreate(...args);
+  }
+  delete(...args) {
+    return this.database.delete(...args);
+  }
+  deleteAll(...args) {
+    return this.database.deleteAll(...args);
+  }
+  save(...args) {
+    return this.database.save(...args);
+  }
+  update(...args) {
+    return this.database.update(...args);
+  }
+  write(...args) {
+    return this.database.write(...args);
+  }
 }
 
 function translateToCoreDatabaseType(type) {

--- a/src/database/UIDatabase.js
+++ b/src/database/UIDatabase.js
@@ -52,22 +52,26 @@ export class UIDatabase {
     }
   }
 
-  delete(type, records, ...rest) {
+  delete(type, record, ...rest) {
     let safeRecordsToDelete;
     let errorMessage;
+    const records = Array.isArray(record) ? record : [record];
+
     switch (type) {
       case 'Transaction':
-        safeRecordsToDelete = records.filtered('status != "finalised"');
-        errorMessage = count => `Blocked deleting ${count} transaction records`;
+        safeRecordsToDelete = records.filter(transaction => !transaction.isFinalised);
+        errorMessage = count =>
+          `Cannot delete finalised transactions. Blocked deleting ${count} transaction records`;
         break;
       default:
         break;
     }
+
     this.database.delete(type, safeRecordsToDelete, ...rest);
 
     // Throw an error if someone managed to try deleting records they should be able to delete
     const recordCountDiff = records.length - safeRecordsToDelete.length;
-    if (!recordCountDiff) {
+    if (recordCountDiff > 0) {
       throw new Error(errorMessage(recordCountDiff));
     }
   }

--- a/src/database/UIDatabase.js
+++ b/src/database/UIDatabase.js
@@ -33,12 +33,31 @@ export class UIDatabase {
     }
   }
 
+  delete(type, records, ...rest) {
+    let safeRecordsToDelete;
+    let errorMessage;
+    switch (type) {
+      case 'Transaction':
+        safeRecordsToDelete = records.filtered('status != "finalised"');
+        errorMessage = count => `Blocked deleting ${count} transaction records`;
+        break;
+      default:
+        break;
+    }
+    this.database.delete(type, safeRecordsToDelete, ...rest);
+
+    // Throw an error if someone managed to try deleting records they should be able to delete
+    const recordCountDiff = records.length - safeRecordsToDelete.length;
+    if (!recordCountDiff) {
+      throw new Error(errorMessage(recordCountDiff));
+    }
+  }
+
   addListener(...args) { return this.database.addListener(...args); }
   removeListener(...args) { return this.database.removeListener(...args); }
   alertListeners(...args) { return this.database.alertListeners(...args); }
   create(...args) { return this.database.create(...args); }
   getOrCreate(...args) { return this.database.getOrCreate(...args); }
-  delete(...args) { return this.database.delete(...args); }
   deleteAll(...args) { return this.database.deleteAll(...args); }
   save(...args) { return this.database.save(...args); }
   update(...args) { return this.database.update(...args); }

--- a/src/database/UIDatabase.js
+++ b/src/database/UIDatabase.js
@@ -52,57 +52,17 @@ export class UIDatabase {
     }
   }
 
-  delete(type, record, ...rest) {
-    let safeRecordsToDelete;
-    let errorMessage;
-    const records = Array.isArray(record) ? record : [record];
+  addListener(...args) { return this.database.addListener(...args); }
+  removeListener(...args) { return this.database.removeListener(...args); }
+  alertListeners(...args) { return this.database.alertListeners(...args); }
+  create(...args) { return this.database.create(...args); }
+  getOrCreate(...args) { return this.database.getOrCreate(...args); }
+  delete(...args) { return this.database.delete(...args); }
+  deleteAll(...args) { return this.database.deleteAll(...args); }
+  save(...args) { return this.database.save(...args); }
+  update(...args) { return this.database.update(...args); }
+  write(...args) { return this.database.write(...args); }
 
-    switch (type) {
-      case 'Transaction':
-        safeRecordsToDelete = records.filter(transaction => !transaction.isFinalised);
-        errorMessage = count =>
-          `Cannot delete finalised transactions. Blocked deleting ${count} transaction records`;
-        break;
-      default:
-        break;
-    }
-
-    this.database.delete(type, safeRecordsToDelete, ...rest);
-
-    // Throw an error if someone managed to try deleting records they should be able to delete
-    const recordCountDiff = records.length - safeRecordsToDelete.length;
-    if (recordCountDiff > 0) {
-      throw new Error(errorMessage(recordCountDiff));
-    }
-  }
-
-  addListener(...args) {
-    return this.database.addListener(...args);
-  }
-  removeListener(...args) {
-    return this.database.removeListener(...args);
-  }
-  alertListeners(...args) {
-    return this.database.alertListeners(...args);
-  }
-  create(...args) {
-    return this.database.create(...args);
-  }
-  getOrCreate(...args) {
-    return this.database.getOrCreate(...args);
-  }
-  deleteAll(...args) {
-    return this.database.deleteAll(...args);
-  }
-  save(...args) {
-    return this.database.save(...args);
-  }
-  update(...args) {
-    return this.database.update(...args);
-  }
-  write(...args) {
-    return this.database.write(...args);
-  }
 }
 
 function translateToCoreDatabaseType(type) {

--- a/src/sync/PostSyncProcessor.js
+++ b/src/sync/PostSyncProcessor.js
@@ -105,6 +105,7 @@ export class PostSyncProcessor {
    * @return {none}
    */
   enqueueFunctionsForRecordType = (recordType, record) => {
+    if (!record) return;
     switch (recordType) {
       case 'Requisition':
         this.functionQueue = this.functionQueue.concat(


### PR DESCRIPTION
Allow deleting a transaction through sync. This is gross, but should only occur when we manually send a delete record (as primary wouldn't normally allow deleting in this way).

Required at this point as a regression in mobile allowed sending customer invoices and requisitions to self (and corresponding supplier invoices), so to clean up we need to be able to run scripts on server to delete transactions.