### PR TITLE
#773 Fix compile error after demo branch merge to develop

### DIFF
--- a/src/localization/demoUserModalStrings.js
+++ b/src/localization/demoUserModalStrings.js
@@ -10,7 +10,7 @@ import LocalizedStrings from 'react-native-localization';
 export const demoUserModalStrings = new LocalizedStrings({
   gb: {
     confirmModalBody: 'One step closer to creating your Demo Store. We need to verify the email address you have provided so that we could generate your store and send you the credentials to it. We have sent you an e-mail with a verification link. Please check your provided email address and click on the verification link.',
-    modalBodyText: 'Request a demo store: Email will be used for verification purposes and for notification of demo store expiry',
+    modalBodyText: 'Request a demo store:\nEmail will be used for verification purposes and for notification of demo store expiry',
   },
   fr: {
   },

--- a/src/widgets/modals/DemoUserModal.js
+++ b/src/widgets/modals/DemoUserModal.js
@@ -197,7 +197,7 @@ export class DemoUserModal extends React.Component {
           <ConfirmModal
             isOpen={this.state.status === 'submitted'}
             questionText={demoUserModalStrings.confirmModalBody}
-            onConfirm={this.onDemoSubmittedModalClose()}
+            onConfirm={this.onDemoSubmittedModalClose}
             confirmText="Close"
           />
         </View>


### PR DESCRIPTION
Fixes #773 

There was a method `onDemoSubmittedModalClose` in `widgets/modals/DemoUserModal.js`, which was being called inside render rather then being bound. This would cause React to infinitely call render in a loop.

The code was compiling in older branch and I did not notice it until it crashed today. After the merge react-native would just not compile the application and would error out to a red screen.

Please look at the issue #773 for error file.

It's very minor fix.