### PR TITLE
Import createOrUpdateRecord in mergeRecords.js

### DIFF
--- a/src/database/utilities/mergeRecords.js
+++ b/src/database/utilities/mergeRecords.js
@@ -1,4 +1,5 @@
-import { deleteRecord } from './deleteRecord'
+import { createOrUpdateRecord } from '../../sync/incomingSyncUtils';
+import { deleteRecord } from './deleteRecord';
 
 // Translations for merge logic.
 // TODO: bind translations to DataType constants to avoid breakage on schema update.


### PR DESCRIPTION
Fixes #778.  

As merge logic is relatively bound to incoming sync, it may be more suitably located in the sync folder. This would avoid the ugly '../../' import statement.